### PR TITLE
chore: release 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 6.2.0 (2023-08-30)
+
+### ⚠ BREAKING CHANGES
+
+* **core:** removed `GfpNativeSimpleAdOptions.Builder.setAdChoicePlacement(int)` method. use `GfpNativeSimpleAdOptions.Builder.setAdChoicesPlacement(int)` instead
+* **core:** removed `GfpNativeAdOptions.Builder.setAdChoicePlacement(int)` method. use `GfpNativeAdOptions.Builder.setAdChoicesPlacement(int)` instead
+
+>Note: There is an interface name change to unify the words used across platforms. We appreciate your understanding that this is a breaking change without a major version change.
+
+### Features
+
+* add api to get media information in native ad objects
+* **core:** add an ad request uri interface on AdParam
+* **core:** add user show interest listener to `GfpAdLoader`
+* **nda:** change ad choices icon in S2S Native Normal ads
+* support s2s native out-stream video ads
+
+### Bug Fixes
+
+* **core:** fix crash when tracking to invalid url
+* **core:** make `GfpDedupeManager` reusable after destroying it
+* **nda:** update ui translations
+* **nda:** video ad pauses when restored after being rewound
+
+### Code Refactoring
+
+* **nda:** ignore playback restriction when user-activated play control
+* **nda:** improve ad mute feedback list page
+* **nda:** modify the logic that determines the ad mute layout type
+* **nda:** only generate blur image only when blur image settings are present
+
 ## 6.1.1 (2023-07-21)
 ### Bug Fixes
 * unplayed ad makes the video content stop after ad schedule is finished

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ android {
 
 ```groovy
 dependencies {
-  implementation platform('com.naver.gfpsdk:nam-bom:6.1.1')
+  implementation platform('com.naver.gfpsdk:nam-bom:6.2.0')
   implementation 'com.naver.gfpsdk:nam-core' // no version specified
 }
 ```

--- a/docs/ad-formats/in_stream.md
+++ b/docs/ad-formats/in_stream.md
@@ -10,7 +10,7 @@ Please check the following 'Implement the AdVideoPlayer'
 ## Step 1: Add dependencies
 ```groovy
 dependencies {
-    implementation platform('com.naver.gfpsdk:nam-bom:6.1.1')
+    implementation platform('com.naver.gfpsdk:nam-bom:6.2.0')
     implementation 'com.naver.gfpsdk:nam-core'
     implementation 'com.naver.gfpsdk:nam-ndavideo'                      // (optional) for instream ads
     implementation 'com.google.android.exoplayer:exoplayer-core:2.18.0' // using exoplayer for example

--- a/docs/ad-providers/dfp.md
+++ b/docs/ad-providers/dfp.md
@@ -28,7 +28,7 @@ repositories {
 
 ...
 dependencies {
-    implementation 'com.naver.gfpsdk:nam-dfp:6.1.1'  
+    implementation 'com.naver.gfpsdk:nam-dfp:6.2.0'  
 }
 ```
 

--- a/docs/ad-providers/fan.md
+++ b/docs/ad-providers/fan.md
@@ -28,7 +28,7 @@ repositories {
 
 ...
 dependencies {
-    implementation 'com.naver.gfpsdk:nam-fan:6.1.1'  
+    implementation 'com.naver.gfpsdk:nam-fan:6.2.0'  
 }
 ```
 

--- a/docs/ad-providers/inmobi.md
+++ b/docs/ad-providers/inmobi.md
@@ -28,7 +28,7 @@ repositories {
 
 ...
 dependencies {
-    implementation 'com.naver.gfpsdk:nam-inmobi:6.1.1'  
+    implementation 'com.naver.gfpsdk:nam-inmobi:6.2.0'  
 }
 ```
 

--- a/docs/ad-providers/nda.md
+++ b/docs/ad-providers/nda.md
@@ -28,7 +28,7 @@ repositories {
 
 ...
 dependencies {
-    implementation 'com.naver.gfpsdk:nam-nda:6.1.1'  
+    implementation 'com.naver.gfpsdk:nam-nda:6.2.0'  
 }
 ```
 

--- a/example/java-sample/build.gradle
+++ b/example/java-sample/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 	implementation 'androidx.multidex:multidex:2.0.1'
 
-	implementation platform('com.naver.gfpsdk:nam-bom:6.1.1')
+	implementation platform('com.naver.gfpsdk:nam-bom:6.2.0')
 	implementation 'com.naver.gfpsdk:nam-core'
 	implementation 'com.naver.gfpsdk:nam-nda' // (optional) s2s mediation dependency
 	implementation 'com.naver.gfpsdk:nam-dfp' // (optional) dfp mediation dependency

--- a/example/java-sample/src/main/java/com/naver/namexample/sample/SmartChannelFragment.java
+++ b/example/java-sample/src/main/java/com/naver/namexample/sample/SmartChannelFragment.java
@@ -79,7 +79,7 @@ public class SmartChannelFragment extends Fragment {
                                 })
                         .withNativeSimpleAd(
                                 new GfpNativeSimpleAdOptions.Builder()
-                                        .setAdChoicePlacement(
+                                        .setAdChoicesPlacement(
                                                 GfpNativeSimpleAdOptions.ADCHOICES_TOP_RIGHT)
                                         .build(),
                                 nativeSimpleAd -> {

--- a/example/kotlin-sample/build.gradle
+++ b/example/kotlin-sample/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 	implementation 'androidx.multidex:multidex:2.0.1'
 
-	implementation platform('com.naver.gfpsdk:nam-bom:6.1.1')
+	implementation platform('com.naver.gfpsdk:nam-bom:6.2.0')
 	implementation 'com.naver.gfpsdk:nam-core'
 	implementation 'com.naver.gfpsdk:nam-nda' // (optional) s2s mediation dependency
 	implementation 'com.naver.gfpsdk:nam-dfp' // (optional) dfp mediation dependency

--- a/example/kotlin-sample/src/main/java/com/naver/namexample/sample/SmartChannelFragment.kt
+++ b/example/kotlin-sample/src/main/java/com/naver/namexample/sample/SmartChannelFragment.kt
@@ -68,7 +68,7 @@ class SmartChannelFragment : Fragment() {
             })
             .withNativeSimpleAd(
                 GfpNativeSimpleAdOptions.Builder()
-                    .setAdChoicePlacement(GfpNativeSimpleAdOptions.ADCHOICES_TOP_RIGHT)
+                    .setAdChoicesPlacement(GfpNativeSimpleAdOptions.ADCHOICES_TOP_RIGHT)
                     .build()
             ) { nativeSimpleAd: GfpNativeSimpleAd ->
                 logTextView.append(

--- a/example/kotlin-sample/src/main/res/layout/content_native_ad.xml
+++ b/example/kotlin-sample/src/main/res/layout/content_native_ad.xml
@@ -46,6 +46,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:textColor="#999999"
+                        android:textStyle=""
                     android:textSize="12sp" />
 
             </LinearLayout>


### PR DESCRIPTION
## :scroll: Description

### ⚠ BREAKING CHANGES

* **core:** removed `GfpNativeSimpleAdOptions.Builder.setAdChoicePlacement(int)` method. use `GfpNativeSimpleAdOptions.Builder.setAdChoicesPlacement(int)` instead
* **core:** removed `GfpNativeAdOptions.Builder.setAdChoicePlacement(int)` method. use `GfpNativeAdOptions.Builder.setAdChoicesPlacement(int)` instead

>Note: There is an interface name change to unify the words used across platforms. We appreciate your understanding that this is a breaking change without a major version change.

### Features

* add api to get media information in native ad objects
* **core:** add an ad request uri interface on AdParam
* **core:** add user show interest listener to `GfpAdLoader`
* **nda:** change ad choices icon in S2S Native Normal ads
* support s2s native out-stream video ads

### Bug Fixes

* **core:** fix crash when tracking to invalid url
* **core:** make `GfpDedupeManager` reusable after destroying it
* **nda:** update ui translations
* **nda:** video ad pauses when restored after being rewound

### Code Refactoring

* **nda:** ignore playback restriction when user-activated play control
* **nda:** improve ad mute feedback list page
* **nda:** modify the logic that determines the ad mute layout type
* **nda:** only generate blur image only when blur image settings are present


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [x] I updated the docs if needed


## :crystal_ball: Next steps
