### PR TITLE
chore: deprecate 6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+## 6.6.0 (2023-11-06)
+
+### ⚠ Deprecated
+* **This version has an issue with mediation not performing correctly. Use the older NAM SDK v6.5.0 instead.**
+
+### Bug Fixes
+* **fan:** fix for native banner not supporting `GfpNativeAd.getMediaData()` ([f588fb8](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/commit/f588fb84dd723c77626a6754dd27cc7c311649d7)), closes [#1512](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/issues/1512)
+* fix cases where vast tracking does not work ([89a69b6](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/commit/89a69b66296201eb991e6dd448a7c8c4655b9db1)), closes [#1502](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/issues/1502)
+
+### Code Refactoring
+* **applovin:** add a validation check in the AppLovin native ad for CTA ([2866eaa](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/commit/2866eaa27c7398df7c8d591560a28303e1e0d266)), closes [#1489](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/issues/1489)
+
 ## 6.5.0 (2023-10-24)
 ### Features
 * add api to get `text` and `highlightedBgColor` of `callToAction` asset

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Naver Ad Manager SDK for Android
 
-![Maven Central](https://img.shields.io/maven-central/v/com.naver.gfpsdk/nam-core)
+![Maven Central](https://img.shields.io/badge/maven--central-v6.5.0-blue)
 
 Integrating the `Naver Ad Manager(NAM) SDK` into an app is the first step toward displaying ads and earning revenue. Once you've integrated the SDK,
 you can choose an ad format (such as banner or native or rewarded or interstitial) and follow the steps to implement it.


### PR DESCRIPTION
## :scroll: Description
### ⚠ Deprecated
* **This version has an issue with mediation not performing correctly. Use the older NAM SDK v6.5.0 instead.**

### Bug Fixes
* **fan:** fix for native banner not supporting `GfpNativeAd.getMediaData()` ([f588fb8](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/commit/f588fb84dd723c77626a6754dd27cc7c311649d7)), closes [#1512](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/issues/1512)
* fix cases where vast tracking does not work ([89a69b6](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/commit/89a69b66296201eb991e6dd448a7c8c4655b9db1)), closes [#1502](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/issues/1502)

### Code Refactoring
* **applovin:** add a validation check in the AppLovin native ad for CTA ([2866eaa](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/commit/2866eaa27c7398df7c8d591560a28303e1e0d266)), closes [#1489](https://oss.navercorp.com/da-ssp-app-sdk/naver_sdk_aos/issues/1489)


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I updated the docs if needed
