### PR TITLE
chore: release 6.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+## 6.7.0 (2023-11-21)
+### Bug Fixes
+* **nda:** fix a clickable area on rewarded companion ad
+
+### Code Refactoring
+* **adplayer:** organize drawables for skip button in in-stream
+* **applovin:** bump `applovin` sdk to 11.10.1
+* **dfp:** bump `dfp` sdk to 22.2.0
+* **fan:** bump `fan` sdk to 6.16.0
+* **inmobi:** bump `inMobi` sdk to 10.5.9
+* **unity:** bump `unity` sdk to 4.8.0
+* **vungle:** bump `vungle` sdk to 7.0.0
+
 ## 6.6.3 (2023-11-20)
 ### Bug Fixes
 * **core:** fix a bug when binding native ads in RecyclerView

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ android {
 
 ```groovy
 dependencies {
-  implementation platform('com.naver.gfpsdk:nam-bom:6.6.3')
+  implementation platform('com.naver.gfpsdk:nam-bom:6.7.0')
   implementation 'com.naver.gfpsdk:nam-core' // no version specified
 }
 ```

--- a/docs/ad-formats/in_stream.md
+++ b/docs/ad-formats/in_stream.md
@@ -10,7 +10,7 @@ Please check the following 'Implement the AdVideoPlayer'
 ## Step 1: Add dependencies
 ```groovy
 dependencies {
-    implementation platform('com.naver.gfpsdk:nam-bom:6.6.3')
+    implementation platform('com.naver.gfpsdk:nam-bom:6.7.0')
     implementation 'com.naver.gfpsdk:nam-core'
     implementation 'com.naver.gfpsdk:nam-ndavideo'                      // (optional) for instream ads
     implementation 'com.google.android.exoplayer:exoplayer-core:2.18.0' // using exoplayer for example

--- a/docs/ad-providers/dfp.md
+++ b/docs/ad-providers/dfp.md
@@ -28,7 +28,7 @@ repositories {
 
 ...
 dependencies {
-    implementation 'com.naver.gfpsdk:nam-dfp:6.6.3'  
+    implementation 'com.naver.gfpsdk:nam-dfp:6.7.0'  
 }
 ```
 

--- a/docs/ad-providers/fan.md
+++ b/docs/ad-providers/fan.md
@@ -28,7 +28,7 @@ repositories {
 
 ...
 dependencies {
-    implementation 'com.naver.gfpsdk:nam-fan:6.6.3'  
+    implementation 'com.naver.gfpsdk:nam-fan:6.7.0'  
 }
 ```
 

--- a/docs/ad-providers/inmobi.md
+++ b/docs/ad-providers/inmobi.md
@@ -28,7 +28,7 @@ repositories {
 
 ...
 dependencies {
-    implementation 'com.naver.gfpsdk:nam-inmobi:6.6.3'  
+    implementation 'com.naver.gfpsdk:nam-inmobi:6.7.0'  
 }
 ```
 

--- a/docs/ad-providers/nda.md
+++ b/docs/ad-providers/nda.md
@@ -28,7 +28,7 @@ repositories {
 
 ...
 dependencies {
-    implementation 'com.naver.gfpsdk:nam-nda:6.6.3'  
+    implementation 'com.naver.gfpsdk:nam-nda:6.7.0'  
 }
 ```
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,7 +2,7 @@
 plugins {
 	id 'com.android.application' version '7.2.0' apply false
 	id 'com.android.library' version '7.2.0' apply false
-	id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+	id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
 	id "com.diffplug.spotless" version "6.7.2" apply true
 }
 

--- a/example/java-sample/build.gradle
+++ b/example/java-sample/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 	implementation 'androidx.multidex:multidex:2.0.1'
 
-	implementation platform('com.naver.gfpsdk:nam-bom:6.6.3')
+	implementation platform('com.naver.gfpsdk:nam-bom:6.7.0')
 	implementation 'com.naver.gfpsdk:nam-core'
 	implementation 'com.naver.gfpsdk:nam-nda' // (optional) s2s mediation dependency
 	implementation 'com.naver.gfpsdk:nam-dfp' // (optional) dfp mediation dependency

--- a/example/kotlin-sample/build.gradle
+++ b/example/kotlin-sample/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 	implementation 'androidx.multidex:multidex:2.0.1'
 
-	implementation platform('com.naver.gfpsdk:nam-bom:6.6.3')
+	implementation platform('com.naver.gfpsdk:nam-bom:6.7.0')
 	implementation 'com.naver.gfpsdk:nam-core'
 	implementation 'com.naver.gfpsdk:nam-nda' // (optional) s2s mediation dependency
 	implementation 'com.naver.gfpsdk:nam-dfp' // (optional) dfp mediation dependency


### PR DESCRIPTION
## :scroll: Description
## 6.7.0 (2023-11-21)
### Bug Fixes
* **nda:** fix a clickable area on rewarded companion ad

### Code Refactoring
* **adplayer:** organize drawables for skip button in in-stream
* **applovin:** bump `applovin` sdk to 11.10.1
* **dfp:** bump `dfp` sdk to 22.2.0
* **fan:** bump `fan` sdk to 6.16.0
* **inmobi:** bump `inMobi` sdk to 10.5.9
* **unity:** bump `unity` sdk to 4.8.0
* **vungle:** bump `vungle` sdk to 7.0.0

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I updated the docs if needed
