### PR TITLE
chore: release 8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,34 @@
 # Changelog
+## 8.2.0 (2024-12-04)
+
+### Bug Fixes
+
+* disconnect even before receiving response when cancelling network request
+
+### Code Refactoring
+
+* load scaled down image into memory when loading image
+
+### GFP SDKs mapped to this BoM version 8.2.0
+|Artifact name|Version mapped this BoM|
+|---|---|
+|com.naver.gfpsdk:gfpsdk-core|8.2.0|
+|com.naver.gfpsdk:gfpsdk-adplayer|8.2.0|
+|com.naver.gfpsdk.mediation:nda|8.2.0|
+|com.naver.gfpsdk.mediation:ndarichmedia|8.2.0|
+|com.naver.gfpsdk.mediation:ndavideo|8.2.0|
+|com.naver.gfpsdk.mediation:applovin|12.6.1.0|
+|com.naver.gfpsdk.mediation:aps|9.10.2.0|
+|com.naver.gfpsdk.mediation:dfp|23.3.0.0|
+|com.naver.gfpsdk.mediation:dt|8.3.0.0|
+|com.naver.gfpsdk.mediation:fan|6.18.0.0|
+|com.naver.gfpsdk.mediation:ima|3.33.0.0|
+|com.naver.gfpsdk.mediation:inmobi|10.7.7.0|
+|com.naver.gfpsdk.mediation:ironsource|8.4.0.0|
+|com.naver.gfpsdk.mediation:lan|2.7.20240214.0|
+|com.naver.gfpsdk.mediation:unity|4.12.3.0|
+|com.naver.gfpsdk.mediation:vungle|7.4.1.0| 
+
 ## 8.1.0 (2024-11-14)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,17 @@
 |com.naver.gfpsdk:gfpsdk-core|8.2.0|
 |com.naver.gfpsdk:gfpsdk-adplayer|8.2.0|
 |com.naver.gfpsdk.mediation:nda|8.2.0|
-|com.naver.gfpsdk.mediation:ndarichmedia|8.2.0|
 |com.naver.gfpsdk.mediation:ndavideo|8.2.0|
 |com.naver.gfpsdk.mediation:applovin|12.6.1.0|
 |com.naver.gfpsdk.mediation:aps|9.10.2.0|
 |com.naver.gfpsdk.mediation:dfp|23.3.0.0|
 |com.naver.gfpsdk.mediation:dt|8.3.0.0|
 |com.naver.gfpsdk.mediation:fan|6.18.0.0|
-|com.naver.gfpsdk.mediation:ima|3.33.0.0|
 |com.naver.gfpsdk.mediation:inmobi|10.7.7.0|
 |com.naver.gfpsdk.mediation:ironsource|8.4.0.0|
 |com.naver.gfpsdk.mediation:lan|2.7.20240214.0|
 |com.naver.gfpsdk.mediation:unity|4.12.3.0|
-|com.naver.gfpsdk.mediation:vungle|7.4.1.0| 
+|com.naver.gfpsdk.mediation:vungle|7.4.1.0|
 
 ## 8.1.0 (2024-11-14)
 

--- a/java-sample/build.gradle
+++ b/java-sample/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'com.google.android.material:material:1.4.0'
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
-	implementation platform('com.naver.gfpsdk:nam-bom:8.1.0')
+	implementation platform('com.naver.gfpsdk:nam-bom:8.2.0')
 	implementation 'com.naver.gfpsdk:nam-core'
 	implementation 'com.naver.gfpsdk.mediation:nam-nda' // (optional) s2s mediation dependency
 	implementation 'com.naver.gfpsdk.mediation:nam-dfp' // (optional) dfp mediation dependency

--- a/kotlin-sample/build.gradle
+++ b/kotlin-sample/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 	implementation 'com.google.android.material:material:1.4.0'
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
-	implementation platform('com.naver.gfpsdk:nam-bom:8.1.0')
+	implementation platform('com.naver.gfpsdk:nam-bom:8.2.0')
 	implementation 'com.naver.gfpsdk:nam-core'
 	implementation 'com.naver.gfpsdk.mediation:nam-nda' // (optional) s2s mediation dependency
 	implementation 'com.naver.gfpsdk.mediation:nam-dfp' // (optional) dfp mediation dependency


### PR DESCRIPTION
## :scroll: Description
### Bug Fixes

* disconnect even before receiving response when cancelling network request

### Code Refactoring

* load scaled down image into memory when loading image

### GFP SDKs mapped to this BoM version 8.2.0
|Artifact name|Version mapped this BoM|
|---|---|
|com.naver.gfpsdk:gfpsdk-core|8.2.0|
|com.naver.gfpsdk:gfpsdk-adplayer|8.2.0|
|com.naver.gfpsdk.mediation:nda|8.2.0|
|com.naver.gfpsdk.mediation:ndavideo|8.2.0|
|com.naver.gfpsdk.mediation:applovin|12.6.1.0|
|com.naver.gfpsdk.mediation:aps|9.10.2.0|
|com.naver.gfpsdk.mediation:dfp|23.3.0.0|
|com.naver.gfpsdk.mediation:dt|8.3.0.0|
|com.naver.gfpsdk.mediation:fan|6.18.0.0|
|com.naver.gfpsdk.mediation:inmobi|10.7.7.0|
|com.naver.gfpsdk.mediation:ironsource|8.4.0.0|
|com.naver.gfpsdk.mediation:lan|2.7.20240214.0|
|com.naver.gfpsdk.mediation:unity|4.12.3.0|
|com.naver.gfpsdk.mediation:vungle|7.4.1.0| 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I updated the docs if needed
