### PR TITLE
chore: release 8.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,30 @@
 # Changelog
+## 8.2.6 (2025-02-10)
+
+
+### Bug Fixes
+
+* fix url parsing error when handling MRAID command
+
+### NAM SDKs mapped to this BoM version 8.2.6
+|Artifact name|Version mapped this BoM|
+|---|---|
+|com.naver.gfpsdk:nam-core|8.2.6|
+|com.naver.gfpsdk:nam-adplayer|8.2.6|
+|com.naver.gfpsdk.mediation:nam-nda|8.2.6|
+|com.naver.gfpsdk.mediation:nam-ndavideo|8.2.6|
+|com.naver.gfpsdk.mediation:nam-applovin|12.6.1.1|
+|com.naver.gfpsdk.mediation:nam-aps|9.10.2.1|
+|com.naver.gfpsdk.mediation:nam-dfp|23.3.0.2|
+|com.naver.gfpsdk.mediation:nam-dt|8.3.5.1|
+|com.naver.gfpsdk.mediation:nam-fan|6.18.0.2|
+|com.naver.gfpsdk.mediation:nam-inmobi|10.7.7.2|
+|com.naver.gfpsdk.mediation:nam-ironsource|8.4.0.1|
+|com.naver.gfpsdk.mediation:nam-lan|2.9.20241129.0|
+|com.naver.gfpsdk.mediation:nam-unity|4.12.3.1|
+|com.naver.gfpsdk.mediation:nam-vungle|7.4.1.1|
+
+
 ## 8.2.5 (2025-01-22)
 ### Bug Fixes
 * Ad view is not displayed on some devices

--- a/java-sample/build.gradle
+++ b/java-sample/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'com.google.android.material:material:1.4.0'
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
-	implementation platform('com.naver.gfpsdk:nam-bom:8.2.5')
+	implementation platform('com.naver.gfpsdk:nam-bom:8.2.6')
 	implementation 'com.naver.gfpsdk:nam-core'
 	implementation 'com.naver.gfpsdk.mediation:nam-nda' // (optional) s2s mediation dependency
 	implementation 'com.naver.gfpsdk.mediation:nam-dfp' // (optional) dfp mediation dependency

--- a/kotlin-sample/build.gradle
+++ b/kotlin-sample/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 	implementation 'com.google.android.material:material:1.4.0'
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
-	implementation platform('com.naver.gfpsdk:nam-bom:8.2.5')
+	implementation platform('com.naver.gfpsdk:nam-bom:8.2.6')
 	implementation 'com.naver.gfpsdk:nam-core'
 	implementation 'com.naver.gfpsdk.mediation:nam-nda' // (optional) s2s mediation dependency
 	implementation 'com.naver.gfpsdk.mediation:nam-dfp' // (optional) dfp mediation dependency


### PR DESCRIPTION
## :scroll: Description

### Bug Fixes

* fix url parsing error when handling MRAID command 

### NAM SDKs mapped to this BoM version 8.2.6
|Artifact name|Version mapped this BoM|
|---|---|
|com.naver.gfpsdk:nam-core|8.2.6|
|com.naver.gfpsdk:nam-adplayer|8.2.6|
|com.naver.gfpsdk.mediation:nam-nda|8.2.6|
|com.naver.gfpsdk.mediation:nam-ndavideo|8.2.6|
|com.naver.gfpsdk.mediation:nam-applovin|12.6.1.1|
|com.naver.gfpsdk.mediation:nam-aps|9.10.2.1|
|com.naver.gfpsdk.mediation:nam-dfp|23.3.0.2|
|com.naver.gfpsdk.mediation:nam-dt|8.3.5.1|
|com.naver.gfpsdk.mediation:nam-fan|6.18.0.2|
|com.naver.gfpsdk.mediation:nam-inmobi|10.7.7.2|
|com.naver.gfpsdk.mediation:nam-ironsource|8.4.0.1|
|com.naver.gfpsdk.mediation:nam-lan|2.9.20241129.0|
|com.naver.gfpsdk.mediation:nam-unity|4.12.3.1|
|com.naver.gfpsdk.mediation:nam-vungle|7.4.1.1| 


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I updated the docs if needed
