### PR TITLE
chore: release 8.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 8.5.0 (2025-06-17)
+
+### Features
+
+* add global `GfpTheme` setting in `SdkProperties`
+* support native template ad
+
+### Code Refactoring
+
+* **nda:** add the overlay badge on Shopping NDA AD
+* **nda:** refactoring the reward ad resources
+* support server side reward validation
+
+> 💡 From version 8.5.0, RewardedAdListener is migrated to Kotlin as an interface.
+
+### NAM SDKs mapped to this BoM version 8.5.0
+|Artifact name|Version mapped this BoM|
+|---|---|
+|com.naver.gfpsdk:nam-core|8.5.0|
+|com.naver.gfpsdk:nam-adplayer|8.5.0|
+|com.naver.gfpsdk.mediation:nam-nda|8.5.0|
+|com.naver.gfpsdk.mediation:nam-ndavideo|8.5.0|
+|com.naver.gfpsdk.mediation:nam-applovin|13.2.0.1|
+|com.naver.gfpsdk.mediation:nam-aps|9.10.2.2|
+|com.naver.gfpsdk.mediation:nam-bidmachine|3.1.1.3|
+|com.naver.gfpsdk.mediation:nam-chartboost|9.7.0.1|
+|com.naver.gfpsdk.mediation:nam-dfp|23.3.0.4|
+|com.naver.gfpsdk.mediation:nam-dt|8.3.6.2|
+|com.naver.gfpsdk.mediation:nam-fan|6.18.0.4|
+|com.naver.gfpsdk.mediation:nam-inmobi|10.8.0.1|
+|com.naver.gfpsdk.mediation:nam-ironsource|8.4.0.4|
+|com.naver.gfpsdk.mediation:nam-lan|2.9.20250110.0|
+|com.naver.gfpsdk.mediation:nam-unity|4.12.3.2|
+|com.naver.gfpsdk.mediation:nam-vungle|7.4.1.2|
+
 ## 8.4.5 (2025-06-10)
 
 ### Code Refactoring

--- a/java-sample/build.gradle
+++ b/java-sample/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'com.google.android.material:material:1.4.0'
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
-	implementation platform('com.naver.gfpsdk:nam-bom:8.4.5')
+	implementation platform('com.naver.gfpsdk:nam-bom:8.5.0')
 	implementation 'com.naver.gfpsdk:nam-core'
 	implementation 'com.naver.gfpsdk.mediation:nam-nda' // (optional) s2s mediation dependency
 	implementation 'com.naver.gfpsdk.mediation:nam-dfp' // (optional) dfp mediation dependency

--- a/kotlin-sample/build.gradle.kts
+++ b/kotlin-sample/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
 		    implementation("com.google.android.material:material:1.4.0")
 		    implementation("androidx.constraintlayout:constraintlayout:2.1.3")
 
-		    implementation(platform("com.naver.gfpsdk:nam-bom:8.4.5"))
+		    implementation(platform("com.naver.gfpsdk:nam-bom:8.5.0"))
 		    implementation("com.naver.gfpsdk:nam-core")
 		    implementation("com.naver.gfpsdk.mediation:nam-nda") // (optional) s2s mediation dependency
 		    implementation("com.naver.gfpsdk.mediation:nam-dfp") // (optional) dfp mediation dependency

--- a/kotlin-sample/src/main/java/com/naver/namexample/sample/RewardedFragment.kt
+++ b/kotlin-sample/src/main/java/com/naver/namexample/sample/RewardedFragment.kt
@@ -55,7 +55,7 @@ class RewardedFragment : Fragment() {
         rewardedAdManager = GfpRewardedAdManager(requireActivity(), adParam)
 
         rewardedAdManager?.setAdListener(
-            object : RewardedAdListener() {
+            object : RewardedAdListener {
                 override fun onAdLoaded(ad: GfpRewardedAd) {
                     logTextView.append(
                         "[${DateUtil.CURR_TIME_STR}] AD Loaded.\n\t\tAdProviderName: ${ad.adProviderName}\n" // ktlint-disable max-line-length

--- a/mediation/dfp/README.md
+++ b/mediation/dfp/README.md
@@ -39,6 +39,17 @@ You can find your app ID in the Ad Manager UI. For `android:value`, insert your 
 ```
 
 # Changelog
+
+## 23.3.0.4 (2025-06-17)
+
+### Bug Fixes
+
+* fix intermittent issue with video ads not rendering
+
+### Built and tested with
+- GFP SDK version 8.4.3
+- DFP SDK version 23.3.0
+
 ## 23.3.0.3 (2025-05-23)
 ### Code Refactoring
 * remove unnecessary internal method


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
## 8.5.0 (2025-06-17)

### Features

* add global `GfpTheme` setting in `SdkProperties`
* support native template ad

### Code Refactoring

* **nda:** add the overlay badge on Shopping NDA AD
* **nda:** refactoring the reward ad resources
* support server side reward validation
 
> 💡 From version 8.5.0, RewardedAdListener is migrated to Kotlin as an interface.

### NAM SDKs mapped to this BoM version 8.5.0
|Artifact name|Version mapped this BoM|
|---|---|
|com.naver.gfpsdk:nam-core|8.5.0|
|com.naver.gfpsdk:nam-adplayer|8.5.0|
|com.naver.gfpsdk.mediation:nam-nda|8.5.0|
|com.naver.gfpsdk.mediation:nam-ndavideo|8.5.0|
|com.naver.gfpsdk.mediation:nam-applovin|13.2.0.1|
|com.naver.gfpsdk.mediation:nam-aps|9.10.2.2|
|com.naver.gfpsdk.mediation:nam-bidmachine|3.1.1.3|
|com.naver.gfpsdk.mediation:nam-chartboost|9.7.0.1|
|com.naver.gfpsdk.mediation:nam-dfp|23.3.0.4|
|com.naver.gfpsdk.mediation:nam-dt|8.3.6.2|
|com.naver.gfpsdk.mediation:nam-fan|6.18.0.4|
|com.naver.gfpsdk.mediation:nam-inmobi|10.8.0.1|
|com.naver.gfpsdk.mediation:nam-ironsource|8.4.0.4|
|com.naver.gfpsdk.mediation:nam-lan|2.9.20250110.0|
|com.naver.gfpsdk.mediation:nam-unity|4.12.3.2|
|com.naver.gfpsdk.mediation:nam-vungle|7.4.1.2| 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I updated the docs if needed
