### PR TITLE
chore: release 8.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 8.11.1 (2026-01-14)
+
+
+### Bug Fixes
+
+* **core:** prevent main thread disk I/O and error on caching ad
+* fix UI not updating after VAST parse error
+* **nda:** skip orientation setting in multi-window mode in FullScreen AD
+
+
+### Code Refactoring
+
+* **core:** refactor the bid token parameter
+* **core:** unify error message format when getting signal
+* **nda:** block mraid.open() without clicking
+* support in-app bidding for DigitalTurbine
+
+### NAM SDKs mapped to this BoM version 8.11.1
+|Artifact name|Version mapped this BoM|
+|---|---|
+|com.naver.gfpsdk:nam-core|8.11.1|
+|com.naver.gfpsdk:nam-adplayer|8.11.1|
+|com.naver.gfpsdk.mediation:nam-nda|8.11.1|
+|com.naver.gfpsdk.mediation:nam-ndavideo|8.11.1|
+|com.naver.gfpsdk.mediation:nam-applovin|13.5.0.0|
+|com.naver.gfpsdk.mediation:nam-aps|11.0.0.1|
+|com.naver.gfpsdk.mediation:nam-bidmachine|3.5.0.0|
+|com.naver.gfpsdk.mediation:nam-chartboost|9.10.2.0|
+|com.naver.gfpsdk.mediation:nam-dfp|24.7.0.0|
+|com.naver.gfpsdk.mediation:nam-dt|8.4.0.0|
+|com.naver.gfpsdk.mediation:nam-fan|6.21.0.0|
+|com.naver.gfpsdk.mediation:nam-inmobi|10.8.7.1|
+|com.naver.gfpsdk.mediation:nam-ironsource|9.1.0.0|
+|com.naver.gfpsdk.mediation:nam-lan|2.9.20251028.0|
+|com.naver.gfpsdk.mediation:nam-pangle|7.5.0.3.2|
+|com.naver.gfpsdk.mediation:nam-unity|4.16.5.0|
+|com.naver.gfpsdk.mediation:nam-vungle|7.6.1.0|
+
 ## 8.11.0 (2025-12-15)
 
 

--- a/java-sample/build.gradle
+++ b/java-sample/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'com.google.android.material:material:1.4.0'
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
-	implementation platform('com.naver.gfpsdk:nam-bom:8.11.0')
+	implementation platform('com.naver.gfpsdk:nam-bom:8.11.1')
 	implementation 'com.naver.gfpsdk:nam-core'
 	implementation 'com.naver.gfpsdk.mediation:nam-nda' // (optional) s2s mediation dependency
 	implementation 'com.naver.gfpsdk.mediation:nam-dfp' // (optional) dfp mediation dependency

--- a/kotlin-sample/build.gradle.kts
+++ b/kotlin-sample/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
 		    implementation("com.google.android.material:material:1.4.0")
 		    implementation("androidx.constraintlayout:constraintlayout:2.1.3")
 
-		    implementation(platform("com.naver.gfpsdk:nam-bom:8.11.0"))
+		    implementation(platform("com.naver.gfpsdk:nam-bom:8.11.1"))
 		    implementation("com.naver.gfpsdk:nam-core")
 		    implementation("com.naver.gfpsdk.mediation:nam-nda") // (optional) s2s mediation dependency
 		    implementation("com.naver.gfpsdk.mediation:nam-dfp") // (optional) dfp mediation dependency

--- a/mediation/applovin/README.md
+++ b/mediation/applovin/README.md
@@ -20,6 +20,17 @@ dependencies {
 ```
 
 # Changelog
+## 13.5.0.0 (2026-01-14)
+
+
+### Code Refactoring
+
+* verified compatibility with AppLovin SDK 13.5.0
+
+### Built and tested with
+- NAM SDK version 8.11.0
+- APPLOVIN SDK version 13.5.0
+
 ## 13.4.0.1 (2025-12-15)
 
 

--- a/mediation/bidmachine/README.md
+++ b/mediation/bidmachine/README.md
@@ -20,6 +20,23 @@ dependencies {
 ```
 
 # Changelog
+## 3.5.0.0 (2026-01-14)
+
+
+### Features
+
+* set BidMachine privacy policy
+
+
+### Code Refactoring
+
+* unify error message format when getting signal
+* verified compatibility with BidMachine SDK 3.5.0
+
+### Built and tested with
+- NAM SDK version 8.11.1
+- BIDMACHINE SDK version 3.5.0
+
 ## 3.3.0.1 (2025-12-15)
 
 

--- a/mediation/chartboost/README.md
+++ b/mediation/chartboost/README.md
@@ -33,6 +33,18 @@ productFlavors {
 ```
 
 # Changelog
+## 9.10.2.0 (2026-01-14)
+
+
+### Code Refactoring
+
+* unify error message format when getting signal
+* verified compatibility with Chartboost SDK 9.10.2
+
+### Built and tested with
+- NAM SDK version 8.11.1
+- CHARTBOOST SDK version 9.10.2
+
 ## 9.9.3.1 (2025-12-15)
 
 

--- a/mediation/dfp/README.md
+++ b/mediation/dfp/README.md
@@ -39,6 +39,17 @@ You can find your app ID in the Ad Manager UI. For `android:value`, insert your 
 ```
 
 # Changelog
+## 24.7.0.0 (2026-01-14)
+
+
+### Code Refactoring
+
+* verified compatibility with DFP SDK 24.7.0
+
+### Built and tested with
+- NAM SDK version 8.11.0
+- DFP SDK version 24.7.0
+
 ## 24.5.0.1 (2025-12-15)
 
 

--- a/mediation/dt/README.md
+++ b/mediation/dt/README.md
@@ -20,6 +20,24 @@ dependencies {
 ```
 
 # Changelog
+## 8.4.0.0 (2026-01-14)
+
+
+### Bug Fixes
+
+* **dt:** support non bidding ad request
+
+
+### Code Refactoring
+
+* support in-app bidding for DigitalTurbine
+* unify error message format when getting signal
+* verified compatibility with DigitalTurbine SDK 8.4.0
+
+### Built and tested with
+- NAM SDK version 8.11.1
+- DT SDK version 8.4.0
+
 ## 8.3.8.1 (2025-12-15)
 
 

--- a/mediation/fan/README.md
+++ b/mediation/fan/README.md
@@ -20,6 +20,18 @@ dependencies {
 ```
 
 # Changelog
+## 6.21.0.0 (2026-01-14)
+
+
+### Code Refactoring
+
+* unify error message format when getting signal
+* verified compatibility with META SDK 6.21.0
+
+### Built and tested with
+- NAM SDK version 8.11.1
+- FAN SDK version 6.21.0
+
 ## 6.20.0.1 (2025-12-15)
 
 

--- a/mediation/ironsource/README.md
+++ b/mediation/ironsource/README.md
@@ -26,6 +26,17 @@ dependencies {
 ```
 
 # Changelog
+## 9.1.0.0 (2026-01-14)
+
+
+### Code Refactoring
+
+* verified compatibility with IronSource SDK 9.1.0
+
+### Built and tested with
+- NAM SDK version 8.11.0
+- IRONSOURCE SDK version 9.1.0
+
 ## 8.11.1.1 (2025-12-15)
 
 

--- a/mediation/lan/README.md
+++ b/mediation/lan/README.md
@@ -20,6 +20,17 @@ dependencies {
 ```
 
 # Changelog
+## 2.9.20251028.0 (2026-01-14)
+
+
+### Code Refactoring
+
+* verified compatibility with LAN SDK v2.9.20251028
+
+### Built and tested with
+- NAM SDK version 8.11.0
+- LAN SDK version 2.9.20251028
+
 ## 2.9.20250110.4 (2025-12-15)
 
 

--- a/mediation/pangle/README.md
+++ b/mediation/pangle/README.md
@@ -26,6 +26,17 @@ dependencies {
 ```
 
 # Changelog
+## 7.5.0.3.2 (2026-01-14)
+
+
+### Code Refactoring
+
+* unify error message format when getting signal
+
+### Built and tested with
+- NAM SDK version 8.11.1
+- PANGLE SDK version 7.5.0.3
+
 ## 7.5.0.3.1 (2025-12-15)
 
 

--- a/mediation/unity/README.md
+++ b/mediation/unity/README.md
@@ -20,6 +20,17 @@ dependencies {
 ```
 
 # Changelog
+## 4.16.5.0 (2026-01-14)
+
+
+### Code Refactoring
+
+* verified compatibility with Unity SDK 4.16.5
+
+### Built and tested with
+- NAM SDK version 8.11.0
+- UNITY SDK version 4.16.5
+
 ## 4.16.1.1 (2025-12-15)
 
 

--- a/mediation/vungle/README.md
+++ b/mediation/vungle/README.md
@@ -20,6 +20,23 @@ dependencies {
 ```
 
 # Changelog
+## 7.6.1.0 (2026-01-14)
+
+
+### Bug Fixes
+
+* **vungle:** support non bidding ad request
+
+
+### Code Refactoring
+
+* unify error message format when getting signal
+* verified compatibility with Vungle SDK 7.6.1
+
+### Built and tested with
+- NAM SDK version 8.11.1
+- VUNGLE SDK version 7.6.1
+
 ## 7.5.1.0 (2025-09-30)
 ### Code Refactoring
 * add ProductType when creating a bid token


### PR DESCRIPTION
## :scroll: Description
### Bug Fixes

* **core:** prevent main thread disk I/O and error on caching ad
* fix UI not updating after VAST parse error
* **nda:** skip orientation setting in multi-window mode in FullScreen AD


### Code Refactoring

* **core:** refactor the bid token parameter
* **core:** unify error message format when getting signal
* **nda:** block mraid.open() without clicking
* support in-app bidding for DigitalTurbine

### NAM SDKs mapped to this BoM version 8.11.1
|Artifact name|Version mapped this BoM|
|---|---|
|com.naver.gfpsdk:nam-core|8.11.1|
|com.naver.gfpsdk:nam-adplayer|8.11.1|
|com.naver.gfpsdk.mediation:nam-nda|8.11.1|
|com.naver.gfpsdk.mediation:nam-ndavideo|8.11.1|
|com.naver.gfpsdk.mediation:nam-applovin|13.5.0.0|
|com.naver.gfpsdk.mediation:nam-aps|11.0.0.1|
|com.naver.gfpsdk.mediation:nam-bidmachine|3.5.0.0|
|com.naver.gfpsdk.mediation:nam-chartboost|9.10.2.0|
|com.naver.gfpsdk.mediation:nam-dfp|24.7.0.0|
|com.naver.gfpsdk.mediation:nam-dt|8.4.0.0|
|com.naver.gfpsdk.mediation:nam-fan|6.21.0.0|
|com.naver.gfpsdk.mediation:nam-inmobi|10.8.7.1|
|com.naver.gfpsdk.mediation:nam-ironsource|9.1.0.0|
|com.naver.gfpsdk.mediation:nam-lan|2.9.20251028.0|
|com.naver.gfpsdk.mediation:nam-pangle|7.5.0.3.2|
|com.naver.gfpsdk.mediation:nam-unity|4.16.5.0|
|com.naver.gfpsdk.mediation:nam-vungle|7.6.1.0|

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I updated the docs if needed
