### PR TITLE
chore: release 8.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 8.12.0 (2026-02-02)
+
+
+### Bug Fixes
+
+* **core:** ad resources were not cached when disk caching
+* **nda:** correct slot spacing in Shopping NDA ad
+* **nda:** fix activity reference passing in fullscreen ads
+* **nda:** fix context leak of some ad
+* **nda:** fix unintended margin issue in MediaView
+
+
+### Code Refactoring
+
+* apply missing VAST macros
+* support GPP specs
+
+### NAM SDKs mapped to this BoM version 8.12.0
+|Artifact name|Version mapped this BoM|
+|---|---|
+|com.naver.gfpsdk:nam-core|8.12.0|
+|com.naver.gfpsdk:nam-adplayer|8.12.0|
+|com.naver.gfpsdk.mediation:nam-nda|8.12.0|
+|com.naver.gfpsdk.mediation:nam-ndavideo|8.12.0|
+|com.naver.gfpsdk.mediation:nam-applovin|13.5.0.1|
+|com.naver.gfpsdk.mediation:nam-aps|11.0.0.1|
+|com.naver.gfpsdk.mediation:nam-bidmachine|3.5.0.1|
+|com.naver.gfpsdk.mediation:nam-chartboost|9.10.2.0|
+|com.naver.gfpsdk.mediation:nam-dfp|24.7.0.0|
+|com.naver.gfpsdk.mediation:nam-dt|8.4.0.0|
+|com.naver.gfpsdk.mediation:nam-fan|6.21.0.1|
+|com.naver.gfpsdk.mediation:nam-inmobi|11.1.0.0|
+|com.naver.gfpsdk.mediation:nam-ironsource|9.1.0.1|
+|com.naver.gfpsdk.mediation:nam-lan|2.9.20251028.0|
+|com.naver.gfpsdk.mediation:nam-pangle|7.5.0.3.2|
+|com.naver.gfpsdk.mediation:nam-unity|4.16.5.1|
+|com.naver.gfpsdk.mediation:nam-vungle|7.6.1.0|
+
 ## 8.11.1 (2026-01-14)
 
 

--- a/java-sample/build.gradle
+++ b/java-sample/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'com.google.android.material:material:1.4.0'
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
-	implementation platform('com.naver.gfpsdk:nam-bom:8.11.1')
+	implementation platform('com.naver.gfpsdk:nam-bom:8.12.0')
 	implementation 'com.naver.gfpsdk:nam-core'
 	implementation 'com.naver.gfpsdk.mediation:nam-nda' // (optional) s2s mediation dependency
 	implementation 'com.naver.gfpsdk.mediation:nam-dfp' // (optional) dfp mediation dependency

--- a/kotlin-sample/build.gradle.kts
+++ b/kotlin-sample/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
 		    implementation("com.google.android.material:material:1.4.0")
 		    implementation("androidx.constraintlayout:constraintlayout:2.1.3")
 
-		    implementation(platform("com.naver.gfpsdk:nam-bom:8.11.1"))
+		    implementation(platform("com.naver.gfpsdk:nam-bom:8.12.0"))
 		    implementation("com.naver.gfpsdk:nam-core")
 		    implementation("com.naver.gfpsdk.mediation:nam-nda") // (optional) s2s mediation dependency
 		    implementation("com.naver.gfpsdk.mediation:nam-dfp") // (optional) dfp mediation dependency

--- a/mediation/applovin/README.md
+++ b/mediation/applovin/README.md
@@ -20,6 +20,17 @@ dependencies {
 ```
 
 # Changelog
+## 13.5.0.1 (2026-02-02)
+
+
+### Code Refactoring
+
+* support GPP specs
+
+### Built and tested with
+- NAM SDK version 8.12.0
+- APPLOVIN SDK version 13.5.0
+
 ## 13.5.0.0 (2026-01-14)
 
 

--- a/mediation/bidmachine/README.md
+++ b/mediation/bidmachine/README.md
@@ -20,6 +20,17 @@ dependencies {
 ```
 
 # Changelog
+## 3.5.0.1 (2026-02-02)
+
+
+### Code Refactoring
+
+* support GPP specs
+
+### Built and tested with
+- NAM SDK version 8.12.0
+- BIDMACHINE SDK version 3.5.0
+
 ## 3.5.0.0 (2026-01-14)
 
 

--- a/mediation/fan/README.md
+++ b/mediation/fan/README.md
@@ -20,6 +20,17 @@ dependencies {
 ```
 
 # Changelog
+## 6.21.0.1 (2026-02-02)
+
+
+### Code Refactoring
+
+* support GPP specs
+
+### Built and tested with
+- NAM SDK version 8.12.0
+- FAN SDK version 6.21.0
+
 ## 6.21.0.0 (2026-01-14)
 
 

--- a/mediation/inmobi/README.md
+++ b/mediation/inmobi/README.md
@@ -20,6 +20,17 @@ dependencies {
 ```
 
 # Changelog
+## 11.1.0.0 (2026-02-02)
+
+
+### Code Refactoring
+
+* verified compatibility with InMobi SDK 11.1.0
+
+### Built and tested with
+- NAM SDK version 8.11.0
+- INMOBI SDK version 11.1.0
+
 ## 10.8.7.1 (2025-12-15)
 
 

--- a/mediation/ironsource/README.md
+++ b/mediation/ironsource/README.md
@@ -26,6 +26,17 @@ dependencies {
 ```
 
 # Changelog
+## 9.1.0.1 (2026-02-02)
+
+
+### Code Refactoring
+
+* support GPP specs
+
+### Built and tested with
+- NAM SDK version 8.12.0
+- IRONSOURCE SDK version 9.1.0
+
 ## 9.1.0.0 (2026-01-14)
 
 

--- a/mediation/unity/README.md
+++ b/mediation/unity/README.md
@@ -20,6 +20,17 @@ dependencies {
 ```
 
 # Changelog
+## 4.16.5.1 (2026-02-02)
+
+
+### Code Refactoring
+
+* support GPP specs
+
+### Built and tested with
+- NAM SDK version 8.12.0
+- UNITY SDK version 4.16.5
+
 ## 4.16.5.0 (2026-01-14)
 
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
## 8.12.0 (2026-02-02)


### Bug Fixes

* **core:** ad resources were not cached when disk caching
* **nda:** correct slot spacing in Shopping NDA ad
* **nda:** fix activity reference passing in fullscreen ads
* **nda:** fix context leak of some ad
* **nda:** fix unintended margin issue in MediaView


### Code Refactoring

* apply missing VAST macros
* support GPP specs

### NAM SDKs mapped to this BoM version 8.12.0
|Artifact name|Version mapped this BoM|
|---|---|
|com.naver.gfpsdk:nam-core|8.12.0|
|com.naver.gfpsdk:nam-adplayer|8.12.0|
|com.naver.gfpsdk.mediation:nam-nda|8.12.0|
|com.naver.gfpsdk.mediation:nam-ndavideo|8.12.0|
|com.naver.gfpsdk.mediation:nam-applovin|13.5.0.1|
|com.naver.gfpsdk.mediation:nam-aps|11.0.0.1|
|com.naver.gfpsdk.mediation:nam-bidmachine|3.5.0.1|
|com.naver.gfpsdk.mediation:nam-chartboost|9.10.2.0|
|com.naver.gfpsdk.mediation:nam-dfp|24.7.0.0|
|com.naver.gfpsdk.mediation:nam-dt|8.4.0.0|
|com.naver.gfpsdk.mediation:nam-fan|6.21.0.1|
|com.naver.gfpsdk.mediation:nam-inmobi|11.1.0.0|
|com.naver.gfpsdk.mediation:nam-ironsource|9.1.0.1|
|com.naver.gfpsdk.mediation:nam-lan|2.9.20251028.0|
|com.naver.gfpsdk.mediation:nam-pangle|7.5.0.3.2|
|com.naver.gfpsdk.mediation:nam-unity|4.16.5.1|
|com.naver.gfpsdk.mediation:nam-vungle|7.6.1.0| 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I updated the docs if needed
